### PR TITLE
chore: 정하는중인 약속 공유 해결1

### DIFF
--- a/src/main/java/timetogeter/context/promise/application/service/PromiseDetailInfoService.java
+++ b/src/main/java/timetogeter/context/promise/application/service/PromiseDetailInfoService.java
@@ -37,7 +37,8 @@ public class PromiseDetailInfoService {
     private final PlaceBoardRepository placeBoardRepository;
 
     // 디테일 확인 - 사용자가 속한 그룹 내 약속을 (정하는중) , (확정완료) 로 구분지어 보여주는 화면 Step1 - 메인 메소드
-    public List<PromiseView1Response> getEncPromiseIdList(String userId) {
+    public List<PromiseView1Response> getEncPromiseIdList(String userId, String groupId) {
+        // groupId는 현재 사용하지 않지만, 향후 그룹 내 모든 약속 조회를 위해 파라미터로 받음
         List<String> encPromiseIds = promiseProxyUserRepository.findPromiseIdsByUserId(userId);
 
         return encPromiseIds.stream()
@@ -47,12 +48,13 @@ public class PromiseDetailInfoService {
 
     // 디테일 확인 - 사용자가 속한 그룹 내 약속을 (정하는중) 로 구분지어 보여주는 화면 Step2 - 메인 메소드
     public List<PromiseView2Response> getPromiseInfoList(String userId, Promiseview2Request request) {
-        //1. request내 각 promiseId들에 대해 PromiseRepository객체를 반환
-        //+ 그냥 반환하는게 아니라, promise 테이블 내에서 groupId에 해당하는 promiseId와 겹치는거만 반환하도록 쿼리 추가
-        List<String> promiseIdList = request.promiseIdList();
         String groupId = request.groupId();
-        List<Promise> promises = promiseRepository.findByGroupIdAndPromiseIdIn(groupId, promiseIdList);
-
+        // TODO: promiseIdList는 받되, 현재는 참고하지 않음. (여러 유저간 정하는중인 약속 동기화가 현재 안돼서 불가피하게.)
+        // 향후 promiseIdList에 있는 promiseId들은 기존 로직대로 처리하고, 없는 promiseId는 보류하는 로직 추가 예정
+        List<String> promiseIdList = request.promiseIdList();
+        
+        // groupId로 그룹 내 모든 약속 조회 (동기화를 위해)
+        List<Promise> promises = promiseRepository.findByGroupId(groupId);
 
         //2. request내 각 promiseId들에 대해 PromiseCheck내의 insConfirmed를 반환
         return promises.stream()

--- a/src/main/java/timetogeter/context/promise/domain/repository/PromiseRepository.java
+++ b/src/main/java/timetogeter/context/promise/domain/repository/PromiseRepository.java
@@ -19,6 +19,9 @@ public interface PromiseRepository extends JpaRepository<Promise, String>, Promi
     @Query(value = "SELECT * FROM promise WHERE group_id = :groupId AND promise_id IN (:promiseIdList)", nativeQuery = true)
     List<Promise> findByGroupIdAndPromiseIdIn(@Param("groupId") String groupId, @Param("promiseIdList") List<String> promiseIdList);
 
+    @Query(value = "SELECT * FROM promise WHERE group_id = :groupId", nativeQuery = true)
+    List<Promise> findByGroupId(@Param("groupId") String groupId);
+
     @Query("SELECT p.managerId FROM Promise p WHERE p.promiseId = :promiseId")
     Optional<String> findMangerById(@Param("promiseId")String promiseId);
 

--- a/src/main/java/timetogeter/context/promise/presentation/controller/PromiseDetailController.java
+++ b/src/main/java/timetogeter/context/promise/presentation/controller/PromiseDetailController.java
@@ -92,9 +92,10 @@ public class PromiseDetailController {
     @SecurityRequirement(name = "BearerAuth")
     @GetMapping(value = "/view1", produces = MediaType.APPLICATION_JSON_VALUE)
     public BaseResponse<List<PromiseView1Response>> view1(
-            @AuthenticationPrincipal UserPrincipal userPrincipal) throws Exception{
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam(required = false) String groupId) throws Exception{
         String userId = userPrincipal.getId();
-        List<PromiseView1Response> response = promiseDetailInfoService.getEncPromiseIdList(userId);
+        List<PromiseView1Response> response = promiseDetailInfoService.getEncPromiseIdList(userId, groupId);
         return new BaseResponse<>(response);
     }
 


### PR DESCRIPTION
- 같은 그룹 내 다른 사용자가 만든 약속은 조회되지 않음
<img width="309" height="388" alt="image"
     src="https://github.com/user-attachments/assets/7410588c-63da-473c-ab6f-8a995420640d" />
- 임시 방편 (groupId에 해당하는 promiseId 모두 조회해서 '약속 정하는 중인 것'은 나오도록 해결
<img width="480" height="300" alt="image" src="https://github.com/user-attachments/assets/b48184b0-2b70-4b8f-bc04-7b51d79a80c2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for filtering promise details by group. The promise detail endpoint now accepts an optional group identifier parameter, enabling users to view promises scoped to a specific group.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->